### PR TITLE
Modification for PartKeepr behind a reverse proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - PARTKEEPR_PARTS_LIMIT
       - PARTKEEPR_USERS_LIMIT
       - PARTKEEPR_SECRET
+      - PARTKEEPR_AUTHENTICATION_PROVIDER
+      - PARTKEEPR_BASE_URL
     ports:
       - "8080:80"
     volumes:

--- a/mkparameters
+++ b/mkparameters
@@ -60,6 +60,7 @@ $values = array(
     'PARTKEEPR_PARTS_LIMIT' => getenv('PARTKEEPR_PARTS_LIMIT') ?: False,
     'PARTKEEPR_USERS_LIMIT' => getenv('PARTKEEPR_USERS_LIMIT') ?: False,
     'PARTKEEPR_SECRET' => getenv('PARTKEEPR_SECRET') ?: 'OJBKOJIKNONAJENLBJJNLFIDPDGKDIED',
+    'PARTKEEPR_BASE_URL' => getenv('PARTKEEPR_BASE_URL') ?: NULL,
 );
 
 echo $template->render($values);

--- a/parameters.template
+++ b/parameters.template
@@ -47,3 +47,6 @@ $container->setParameter('partkeepr.parts.internalpartnumberunique', filter_var(
 $container->setParameter('partkeepr.parts.limit', filter_var('{{ PARTKEEPR_PARTS_LIMIT }}', FILTER_VALIDATE_BOOLEAN));
 $container->setParameter('partkeepr.users.limit', filter_var('{{ PARTKEEPR_USERS_LIMIT }}', FILTER_VALIDATE_BOOLEAN));
 $container->setParameter('secret', '{{ PARTKEEPR_SECRET }}');
+{% if PARTKEEPR_BASE_URL %}
+$container->setParameter('partkeepr.frontend.base_url', '{{PARTKEEPR_BASE_URL}}');
+{% endif %}


### PR DESCRIPTION
I run your Partkeepr-Docker behind a reverse proxy. For that I have to make the modification which are written hier;

[KB00008:PartKeepr behind a reverse proxy](https://wiki.partkeepr.org/wiki/KB00008:PartKeepr_behind_a_reverse_proxy)

I had to add the PARTKEEPR_BASE_URL environment variable in the docker and also modify the script which generate the parameters.php file.

Maybe it is possible to remove the "if" statement in the "parameters.template" but I don't know if it has some side effects.